### PR TITLE
fix: all info logs are flagged as error logs

### DIFF
--- a/logr.go
+++ b/logr.go
@@ -27,7 +27,7 @@ func ContextualizeLogr(logger logr.Logger, ctx context.Context) logr.Logger {
 func NewLogr(logger *logrus.Logger) logr.Logger {
 	return logr.New(&logrusLogger{
 		logger: logrus.NewEntry(logger),
-		level:  logrus.InfoLevel,
+		level:  logrus.GetLevel(),
 	})
 }
 
@@ -40,7 +40,9 @@ func NewLogr(logger *logrus.Logger) logr.Logger {
 // while the err field should be used to attach the actual error that
 // triggered this log line, if present.
 func (l *logrusLogger) Error(err error, msg string, keysAndValues ...interface{}) {
-	l.Info(0, msg, append(keysAndValues, "error", err)...)
+	if l.Enabled(0) {
+		l.logrusWithValues(append(keysAndValues, "error", err)...).Log(logrus.ErrorLevel, msg)
+	}
 }
 
 // WithValues adds some key-value pairs of context to a logger.
@@ -119,14 +121,10 @@ func (l *logrusLogger) logrusWithValues(keysAndValues ...interface{}) *logrus.En
 func logrLevelToLogrus(level int) logrus.Level {
 	switch level {
 	case 0:
-		return logrus.ErrorLevel
-	case 1:
-		return logrus.WarnLevel
-	case 2:
 		return logrus.InfoLevel
-	case 3:
+	case 1:
 		return logrus.DebugLevel
-	case 4:
+	case 2:
 		return logrus.TraceLevel
 	default:
 		return logrus.TraceLevel

--- a/logr_test.go
+++ b/logr_test.go
@@ -26,56 +26,90 @@ func (t timeSetterHook) Fire(entry *logrus.Entry) error {
 	return nil
 }
 
-func initTestLogrus() (gologr.Logger, *bytes.Buffer) {
+func initTestLogrus(level logrus.Level) (gologr.Logger, *bytes.Buffer) {
 	b := new(bytes.Buffer)
 	l := logrus.New()
 	l.AddHook(timeSetterHook{})
-	l.SetLevel(logrus.TraceLevel)
+	l.SetLevel(level)
 	l.SetFormatter(&logrus.JSONFormatter{})
 	l.SetOutput(b)
 	return log.NewLogr(l), b
 }
 
 func TestError(t *testing.T) {
-	tested, b := initTestLogrus()
+	tested, b := initTestLogrus(logrus.TraceLevel)
 	tested.Error(errors.New("testError"), "this is a test", "some-context", "help")
 	assert.JSONEq(t, `{"error":"testError","some-context": "help","level":"error","msg":"this is a test","time":"2020-03-13T14:00:00Z"}`, b.String())
 }
 
 func TestWithName(t *testing.T) {
-	tested, b := initTestLogrus()
-	tested.V(2).WithName("pkg").WithName("method").Info("hello world")
+	tested, b := initTestLogrus(logrus.TraceLevel)
+	tested.V(0).WithName("pkg").WithName("method").Info("hello world")
 	assert.JSONEq(t, `{"level":"info","msg":"hello world", "name": "pkg.method","time":"2020-03-13T14:00:00Z"}`, b.String())
 }
 
-func TestWithLevel(t *testing.T) {
-	tested, b := initTestLogrus()
+func TestLogrusTraceLevelWithLogrLevel(t *testing.T) {
+	tested, b := initTestLogrus(logrus.TraceLevel)
 	tested.V(0).Info("hello world")
-	assert.JSONEq(t, `{"level":"error","msg":"hello world","time":"2020-03-13T14:00:00Z"}`, b.String())
-
-	b.Reset()
-	tested.V(1).Info("hello world")
-	assert.JSONEq(t, `{"level":"warning","msg":"hello world","time":"2020-03-13T14:00:00Z"}`, b.String())
-
-	b.Reset()
-	tested.V(2).Info("hello world")
 	assert.JSONEq(t, `{"level":"info","msg":"hello world","time":"2020-03-13T14:00:00Z"}`, b.String())
 
 	b.Reset()
-	tested.V(3).Info("hello world")
+	tested.V(0).Error(errors.New("testError"), "this is a test", "some-context", "help")
+	assert.JSONEq(t, `{"error":"testError","some-context": "help","level":"error","msg":"this is a test","time":"2020-03-13T14:00:00Z"}`, b.String())
+
+	b.Reset()
+	tested.V(1).Info("hello world")
 	assert.JSONEq(t, `{"level":"debug","msg":"hello world","time":"2020-03-13T14:00:00Z"}`, b.String())
+
+	b.Reset()
+	tested.V(1).Error(errors.New("testError"), "this is a test", "some-context", "help")
+	assert.JSONEq(t, `{"error":"testError","some-context": "help","level":"error","msg":"this is a test","time":"2020-03-13T14:00:00Z"}`, b.String())
+
+	b.Reset()
+	tested.V(2).Info("hello world")
+	assert.JSONEq(t, `{"level":"trace","msg":"hello world","time":"2020-03-13T14:00:00Z"}`, b.String())
+
+	b.Reset()
+	tested.V(2).Error(errors.New("testError"), "this is a test", "some-context", "help")
+	assert.JSONEq(t, `{"error":"testError","some-context": "help","level":"error","msg":"this is a test","time":"2020-03-13T14:00:00Z"}`, b.String())
+
+	b.Reset()
+	tested.V(3).Info("hello world")
+	assert.JSONEq(t, `{"level":"trace","msg":"hello world","time":"2020-03-13T14:00:00Z"}`, b.String())
+
+	b.Reset()
+	tested.V(3).Error(errors.New("testError"), "this is a test", "some-context", "help")
+	assert.JSONEq(t, `{"error":"testError","some-context": "help","level":"error","msg":"this is a test","time":"2020-03-13T14:00:00Z"}`, b.String())
 
 	b.Reset()
 	tested.V(4).Info("hello world")
 	assert.JSONEq(t, `{"level":"trace","msg":"hello world","time":"2020-03-13T14:00:00Z"}`, b.String())
 
 	b.Reset()
-	tested.V(5).Info("hello world")
-	assert.JSONEq(t, `{"level":"trace","msg":"hello world","time":"2020-03-13T14:00:00Z"}`, b.String())
+	tested.V(4).Error(errors.New("testError"), "this is a test", "some-context", "help")
+	assert.JSONEq(t, `{"error":"testError","some-context": "help","level":"error","msg":"this is a test","time":"2020-03-13T14:00:00Z"}`, b.String())
+}
+
+func TestLogrusInfoLevelWithLogrLevel(t *testing.T) {
+	tested, b := initTestLogrus(logrus.InfoLevel)
+	tested.V(0).Info("hello world")
+	assert.JSONEq(t, `{"level":"info","msg":"hello world","time":"2020-03-13T14:00:00Z"}`, b.String())
+
+	b.Reset()
+	tested.V(0).Error(errors.New("testError"), "this is a test", "some-context", "help")
+	assert.JSONEq(t, `{"error":"testError","some-context": "help","level":"error","msg":"this is a test","time":"2020-03-13T14:00:00Z"}`, b.String())
+
+	b.Reset()
+	tested.V(1).Info("hello world")
+	assert.Empty(t, b.String())
+
+	b.Reset()
+	tested.V(1).Error(errors.New("testError"), "this is a test", "some-context", "help")
+	assert.JSONEq(t, `{"error":"testError","some-context": "help","level":"error","msg":"this is a test","time":"2020-03-13T14:00:00Z"}`, b.String())
 }
 
 func TestEnabled(t *testing.T) {
-	tested, _ := initTestLogrus()
+	tested, _ := initTestLogrus(logrus.TraceLevel)
 	assert.True(t, tested.Enabled())
 
 	tested = log.NewLogr(nil)

--- a/logr_test.go
+++ b/logr_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -48,64 +49,60 @@ func TestWithName(t *testing.T) {
 	assert.JSONEq(t, `{"level":"info","msg":"hello world", "name": "pkg.method","time":"2020-03-13T14:00:00Z"}`, b.String())
 }
 
-func TestLogrusTraceLevelWithLogrLevel(t *testing.T) {
-	tested, b := initTestLogrus(logrus.TraceLevel)
-	tested.V(0).Info("hello world")
-	assert.JSONEq(t, `{"level":"info","msg":"hello world","time":"2020-03-13T14:00:00Z"}`, b.String())
+func TestLogrLevelsWithLogrusLevels(t *testing.T) {
+	tests := []struct {
+		logrusLevel       logrus.Level
+		logrLevel         int
+		expectedInfoLevel string
+	}{
+		{
+			logrusLevel:       logrus.TraceLevel,
+			logrLevel:         0,
+			expectedInfoLevel: "info",
+		},
+		{
+			logrusLevel:       logrus.TraceLevel,
+			logrLevel:         1,
+			expectedInfoLevel: "debug",
+		},
+		{
+			logrusLevel:       logrus.TraceLevel,
+			logrLevel:         2,
+			expectedInfoLevel: "trace",
+		},
+		{
+			logrusLevel:       logrus.TraceLevel,
+			logrLevel:         3,
+			expectedInfoLevel: "trace",
+		},
+		{
+			logrusLevel:       logrus.InfoLevel,
+			logrLevel:         0,
+			expectedInfoLevel: "info",
+		},
+		{
+			logrusLevel: logrus.InfoLevel,
+			logrLevel:   1,
+		},
+	}
 
-	b.Reset()
-	tested.V(0).Error(errors.New("testError"), "this is a test", "some-context", "help")
-	assert.JSONEq(t, `{"error":"testError","some-context": "help","level":"error","msg":"this is a test","time":"2020-03-13T14:00:00Z"}`, b.String())
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("V(%d) with Logrus %s level", tt.logrLevel, tt.logrusLevel.String()), func(t *testing.T) {
+			tested, b := initTestLogrus(tt.logrusLevel)
+			tested.V(tt.logrLevel).Info("hello world")
 
-	b.Reset()
-	tested.V(1).Info("hello world")
-	assert.JSONEq(t, `{"level":"debug","msg":"hello world","time":"2020-03-13T14:00:00Z"}`, b.String())
+			if tt.expectedInfoLevel == "" {
+				assert.Empty(t, b.String())
+			} else {
+				expectedLog := fmt.Sprintf(`{"level":"%s","msg":"hello world","time":"2020-03-13T14:00:00Z"}`, tt.expectedInfoLevel)
+				assert.JSONEq(t, expectedLog, b.String())
+			}
 
-	b.Reset()
-	tested.V(1).Error(errors.New("testError"), "this is a test", "some-context", "help")
-	assert.JSONEq(t, `{"error":"testError","some-context": "help","level":"error","msg":"this is a test","time":"2020-03-13T14:00:00Z"}`, b.String())
-
-	b.Reset()
-	tested.V(2).Info("hello world")
-	assert.JSONEq(t, `{"level":"trace","msg":"hello world","time":"2020-03-13T14:00:00Z"}`, b.String())
-
-	b.Reset()
-	tested.V(2).Error(errors.New("testError"), "this is a test", "some-context", "help")
-	assert.JSONEq(t, `{"error":"testError","some-context": "help","level":"error","msg":"this is a test","time":"2020-03-13T14:00:00Z"}`, b.String())
-
-	b.Reset()
-	tested.V(3).Info("hello world")
-	assert.JSONEq(t, `{"level":"trace","msg":"hello world","time":"2020-03-13T14:00:00Z"}`, b.String())
-
-	b.Reset()
-	tested.V(3).Error(errors.New("testError"), "this is a test", "some-context", "help")
-	assert.JSONEq(t, `{"error":"testError","some-context": "help","level":"error","msg":"this is a test","time":"2020-03-13T14:00:00Z"}`, b.String())
-
-	b.Reset()
-	tested.V(4).Info("hello world")
-	assert.JSONEq(t, `{"level":"trace","msg":"hello world","time":"2020-03-13T14:00:00Z"}`, b.String())
-
-	b.Reset()
-	tested.V(4).Error(errors.New("testError"), "this is a test", "some-context", "help")
-	assert.JSONEq(t, `{"error":"testError","some-context": "help","level":"error","msg":"this is a test","time":"2020-03-13T14:00:00Z"}`, b.String())
-}
-
-func TestLogrusInfoLevelWithLogrLevel(t *testing.T) {
-	tested, b := initTestLogrus(logrus.InfoLevel)
-	tested.V(0).Info("hello world")
-	assert.JSONEq(t, `{"level":"info","msg":"hello world","time":"2020-03-13T14:00:00Z"}`, b.String())
-
-	b.Reset()
-	tested.V(0).Error(errors.New("testError"), "this is a test", "some-context", "help")
-	assert.JSONEq(t, `{"error":"testError","some-context": "help","level":"error","msg":"this is a test","time":"2020-03-13T14:00:00Z"}`, b.String())
-
-	b.Reset()
-	tested.V(1).Info("hello world")
-	assert.Empty(t, b.String())
-
-	b.Reset()
-	tested.V(1).Error(errors.New("testError"), "this is a test", "some-context", "help")
-	assert.JSONEq(t, `{"error":"testError","some-context": "help","level":"error","msg":"this is a test","time":"2020-03-13T14:00:00Z"}`, b.String())
+			b.Reset()
+			tested.V(tt.logrLevel).Error(errors.New("testError"), "this is a test", "some-context", "help")
+			assert.JSONEq(t, `{"error":"testError","some-context": "help","level":"error","msg":"this is a test","time":"2020-03-13T14:00:00Z"}`, b.String())
+		})
+	}
 }
 
 func TestEnabled(t *testing.T) {

--- a/logr_test.go
+++ b/logr_test.go
@@ -76,6 +76,20 @@ func TestLogrLevelsWithLogrusLevels(t *testing.T) {
 			expectedInfoLevel: "trace",
 		},
 		{
+			logrusLevel:       logrus.DebugLevel,
+			logrLevel:         0,
+			expectedInfoLevel: "info",
+		},
+		{
+			logrusLevel:       logrus.DebugLevel,
+			logrLevel:         1,
+			expectedInfoLevel: "debug",
+		},
+		{
+			logrusLevel: logrus.DebugLevel,
+			logrLevel:   2,
+		},
+		{
 			logrusLevel:       logrus.InfoLevel,
 			logrLevel:         0,
 			expectedInfoLevel: "info",

--- a/logr_test.go
+++ b/logr_test.go
@@ -86,8 +86,9 @@ func TestLogrLevelsWithLogrusLevels(t *testing.T) {
 			expectedInfoLevel: "debug",
 		},
 		{
-			logrusLevel: logrus.DebugLevel,
-			logrLevel:   2,
+			logrusLevel:       logrus.DebugLevel,
+			logrLevel:         2,
+			expectedInfoLevel: "<DROPPED_LOG>",
 		},
 		{
 			logrusLevel:       logrus.InfoLevel,
@@ -95,8 +96,9 @@ func TestLogrLevelsWithLogrusLevels(t *testing.T) {
 			expectedInfoLevel: "info",
 		},
 		{
-			logrusLevel: logrus.InfoLevel,
-			logrLevel:   1,
+			logrusLevel:       logrus.InfoLevel,
+			logrLevel:         1,
+			expectedInfoLevel: "<DROPPED_LOG>",
 		},
 	}
 
@@ -105,7 +107,7 @@ func TestLogrLevelsWithLogrusLevels(t *testing.T) {
 			tested, b := initTestLogrus(tt.logrusLevel)
 			tested.V(tt.logrLevel).Info("hello world")
 
-			if tt.expectedInfoLevel == "" {
+			if tt.expectedInfoLevel == "<DROPPED_LOG>" {
 				assert.Empty(t, b.String())
 			} else {
 				expectedLog := fmt.Sprintf(`{"level":"%s","msg":"hello world","time":"2020-03-13T14:00:00Z"}`, tt.expectedInfoLevel)


### PR DESCRIPTION
Context
---
`controllerruntime.Log`[^1] always return a `logr.Logger` with verbosity level set to 0  (least verbosity level).

Problem
---
With the current implementation, calling `controllerruntime.Log.Info(msg)` will always print `msg` as en error.

Changes
---
Map `V(0)` logr baseline verbosity level to `logrus.InfoLevel`. (previously V(0) was mapped to `logrus.ErrorLevel`, even for Info() calls)

This will enable `controllerruntime.Log.Info(msg)` to print `msg` with info level. Subsequently increasing V will increase also the verbosity level, ie:

`controllerruntime.Log.V(0).Info(msg)` --> prints an info message (before it printed an error msg)
`controllerruntime.Log.V(1).Info(msg)` --> prints a debug message
`controllerruntime.Log.V(2).Info(msg)` --> prints a trace message



[^1]: <https://github.com/kubernetes-sigs/controller-runtime/blob/4cae9dfbf174fa5d49ebca007bd6f3784cf1ffb3/pkg/log/log.go#L87>